### PR TITLE
Resolve CA cert related crash when using middleman in a container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+
+## [0.1.3] - 2024-02-08
+
+### Fixed
+
+- Avoid crash when using docker container due to missing CA certificates
+
+## [0.1.2] - 2023-10-17
+
+### Added
+
+- Added `--replay-only` flag to ensure only replays and no recordings are made. Useful in CI.
+
+## [0.1.1] - 2023-10-16
+
+### Added
+
+- Initial release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "middleman"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "middleman"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN     cargo build --release
 FROM debian:bookworm AS runtime
 
 RUN apt-get update \
-    && apt-get install --assume-yes --quiet openssl \
+    && apt-get install --assume-yes --quiet \
+       openssl ca-certificates \
     && rm --recursive --force /var/lib/cache /var/lib/apt/lists
 
 RUN  mkdir --parents /middleman/tapes /middleman/etc


### PR DESCRIPTION
This PR does the following:

* Resolves a `CA Cert missing` crash by installing the `ca-certificates` apt package.
* Bumps the patch version
* Adds a changelog