### PR TITLE
Add x-middleman-passthrough Header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "middleman"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "middleman"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Starts a reverse proxy to <UPSTREAM>, listens on <BIND>:<PORT>.
 Records upstream responses to <TAPES> directory.
 Returns recorded response if url matches (does not call upstream in this case).
 
+The optional header `x-middleman-passthrough` can be specified in http requests to middleman to pass a request through to the <UPSTREAM>.
+Any value other than the exact string "false" will be considered Truthy.
+The `--replay-only` config flag takes precedence over the `x-middleman-passthrough` header.
+
 Usage: middleman [OPTIONS]
 
 Options:

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ static DEFAULT_CONFIG_FILENAME: &str = "middleman.toml";
 #[command(
     author,
     version,
-    about = "Starts a reverse proxy to <UPSTREAM>, listens on <BIND>:<PORT>.\nRecords upstream responses to <TAPES> directory.\nReturns recorded response if url matches (does not call upstream in this case)."
+    about = "Starts a reverse proxy to <UPSTREAM>, listens on <BIND>:<PORT>.\nRecords upstream responses to <TAPES> directory.\nReturns recorded response if url matches (does not call upstream in this case).\n\nThe optional header `x-middleman-passthrough` can be specified in http requests to middleman to pass a request through to the <UPSTREAM>.\nAny value other than the exact string \"false\" will be considered Truthy.\nThe `--replay-only` config flag takes precedence over the `x-middleman-passthrough` header."
 )]
 pub struct CliArgs {
     /// the port to listen on


### PR DESCRIPTION
This header allows for specific requests from a client to be passed through to the upstream.
This is useful when testing scenarios outside the recordings, such as error responses.